### PR TITLE
Make Enum question mark methods work

### DIFF
--- a/lib/active_record/enum_override.rb
+++ b/lib/active_record/enum_override.rb
@@ -41,7 +41,7 @@ module ActiveRecord
 
         # def active?() status == 0 end
         klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
-        define_method("#{value_method_name}?") { self[attr] == value.to_s }
+        define_method("#{value_method_name}?") { self[attr] == value.to_sym }
 
         # def active!() update! status: :active end
         klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")

--- a/lib/sql_enum/version.rb
+++ b/lib/sql_enum/version.rb
@@ -1,3 +1,3 @@
 module SqlEnum
-  VERSION = "0.1.18"
+  VERSION = "0.1.19"
 end


### PR DESCRIPTION
Make it so that enum check method names work. Example, I have
    an enum on a model that has [:active, :inactive, :eligible]
    as possible states. If the model has :active value as the
    enum value for its state, I should be able to do
    the_model.active? and get true. Right now it tries to compare
    the enum value with a string when they are all symbols.