### PR TITLE
fixing incompatibility with decorate_attribute_type in Rails 6.1

### DIFF
--- a/lib/active_record/enum_override.rb
+++ b/lib/active_record/enum_override.rb
@@ -20,8 +20,15 @@ module ActiveRecord
       detect_enum_conflict!(name, "#{name}=")
 
       attr = attribute_alias?(name) ? attribute_alias(name) : name
-      decorate_attribute_type(attr, :enum) do |subtype|
-        EnumType.new(attr, enum_values, subtype)
+
+      if Rails.version >= '6.1'
+        decorate_attribute_type(name) do |subtype|
+          EnumType.new(attr, enum_values, subtype)
+        end
+      else
+        decorate_attribute_type(attr, :enum) do |subtype|
+          EnumType.new(attr, enum_values, subtype)
+        end
       end
 
       enum_values = values(name)

--- a/lib/sql_enum/version.rb
+++ b/lib/sql_enum/version.rb
@@ -1,3 +1,3 @@
 module SqlEnum
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
sql_enum uses the internal method decorate_attribute_type, which changed in Rails 6.1:
https://github.com/y-yagi/enumerize/commit/583495803ff67f0ce20283e1f6b51d4e39ee6039