### PR TITLE
redefine error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sql_enum (0.3.1)
+    sql_enum (0.3.2)
       activerecord (>= 5.1)
       activesupport (>= 5.1)
       mysql2

--- a/lib/sql_enum/class_methods.rb
+++ b/lib/sql_enum/class_methods.rb
@@ -1,6 +1,9 @@
 module SqlEnum
   module ClassMethods
     def sql_enum(column_name, options = {})
+      # skip redefinitions
+      return if defined_enums.key?(column_name.to_s)
+
       # Query values
       enum_column = EnumColumn.new(table_name, column_name)
       values_map = enum_column.values.to_h { |value| [value.to_sym, value.to_s] }
@@ -26,8 +29,8 @@ module SqlEnum
 
       # Fix query methods to compare symbols to symbols
       values_map.each_value do |value|
-        method_name = "#{prefix_str}#{value}#{suffix_str}"
-        define_method("#{method_name}?") { self[column_name] == value.to_sym }
+        method_name = "#{prefix_str}#{value}#{suffix_str}?"
+        define_method(method_name) { self[column_name] == value.to_sym }
       end
     end
 

--- a/lib/sql_enum/version.rb
+++ b/lib/sql_enum/version.rb
@@ -1,3 +1,3 @@
 module SqlEnum
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require "bundler/setup"
+require "debug"
 require "sql_enum"
-
-require 'debug'
 
 Dir['spec/support/**/*.rb'].each { |f| require File.expand_path(f) }
 
@@ -14,5 +13,18 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  # allow "fit" examples
+  config.filter_run_when_matching :focus
+
+  config.include DefineConstantMacros
+
+  config.before(:all) do
+    ActiveRecord::Base.establish_connection(ENV.fetch('DATABASE_URL'))
+  end
+
+  config.after do
+    clear_generated_tables
   end
 end

--- a/spec/sql_enum_spec.rb
+++ b/spec/sql_enum_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe SqlEnum do
   it "has a version number" do
     expect(SqlEnum::VERSION).not_to be_nil
@@ -17,6 +15,8 @@ RSpec.describe SqlEnum do
                    priority: [:enum, limit: priorities]) do
         sql_enum :status
         sql_enum :priority, _prefix: false, _suffix: true
+
+        sql_enum :status # duplicate should be no-op
       end
     end
 

--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -56,15 +56,3 @@ module DefineConstantMacros
     @created_tables ||= []
   end
 end
-
-RSpec.configure do |config|
-  config.include DefineConstantMacros
-
-  config.before(:all) do
-    ActiveRecord::Base.establish_connection(ENV.fetch('DATABASE_URL'))
-  end
-
-  config.after do
-    clear_generated_tables
-  end
-end


### PR DESCRIPTION
avoid redefining methods that already exist since Rails explodes...eg. in case classes get loaded twice

and clean up specs


![image](https://user-images.githubusercontent.com/918804/169624061-b97e3244-c451-4394-b561-b076cc582957.png)
