### PR TITLE
build: set homepage_uri & source_code_uri metadata

### DIFF
--- a/sql_enum.gemspec
+++ b/sql_enum.gemspec
@@ -13,6 +13,11 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/1debit/sql_enum"
   spec.license       = "MIT"
 
+  spec.metadata = {
+    'homepage_uri' => spec.homepage,
+    'source_code_uri' => spec.homepage,
+  }
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
@@ -24,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.1"
   spec.add_dependency "mysql2"
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "debug"
-  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "debug"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
So that Dependabot can create better PR descriptions (not just with commits like it does now):

![image](https://user-images.githubusercontent.com/77458688/172429215-4671d79f-913b-4c15-bdb9-b988d47c15bc.png)
