### PR TITLE
[CI-328] Pin Ubuntu version for GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           - '6.1'
           - '7.0'
           - '7.1'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     name: RSpec (Rails ${{ matrix.rails }}) (Ruby ${{ matrix.ruby }})
 


### PR DESCRIPTION
[GitHub is updating the version of Ubuntu](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/) used by the `ubuntu-latest` tag, including removing some packages. What's worse is that we don't have an exact date, but it's supposed to happen sometime between Dec 5 and Jan 17.

This could potentially result in difficult to predict failures to workflows, especially difficult to test if they run only on the `main` branch and not as part of pull requests on feature branches.

Note that we no longer recommend using the floating `ubuntu-latest` tag going forward.