### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,4 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Test
-        run: docker-compose run --rm rspec bundle exec appraisal rails-${{ matrix.rails }} rspec
+        run: docker compose run --rm rspec bundle exec appraisal rails-${{ matrix.rails }} rspec

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ end
 
 ### Testing
 
-Run `docker-compose run --rm rspec` to run the specs in a docker container alongside Mysql.
+Run `docker compose run --rm rspec` to run the specs in a docker container alongside Mysql.
 
 ## Contributing
 


### PR DESCRIPTION
The build is currently failing as `docker-compose` has been replaced with `docker compose`:
```
/home/runner/work/_temp/17ff886f-1ab8-483d-86cf-8865a0037520.sh: line 1: docker-compose: command not found
Error: Process completed with exit code 127.
```